### PR TITLE
(Issue #27) Fix rendering stalling on multi-segment timelines

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -84,6 +84,22 @@ export const record = async (
   onProgress: (progress: number) => unknown
 ) =>
   new Promise<string>((resolve) => {
+    // The chunks are concatenated across segments and repeats, so their
+    // original per-file timestamps reset backwards at every boundary. A
+    // non-monotonic timestamp makes VideoDecoder error out and close the
+    // codec, after which every further decode() throws InvalidStateError.
+    // Rewrite the timestamps into one strictly increasing sequence.
+    chunks = chunks.map((chunk, i) => {
+      const data = new Uint8Array(chunk.byteLength);
+      chunk.copyTo(data);
+      return new EncodedVideoChunk({
+        type: chunk.type,
+        timestamp: (i * 1e6) / FPS,
+        duration: 1e6 / FPS,
+        data,
+      });
+    });
+
     const canvas = document.createElement("canvas");
     canvas.width = settings.width;
     canvas.height = settings.height;


### PR DESCRIPTION
Chunks from each clip start their timestamps at 0, so concatenating segments (or repeating one) makes the timestamps jump backwards. Chrome's VideoDecoder doesn't like that and closes the codec, which then spams "decode on a closed codec" errors and stalls the render.
Rendering would pause partway through and the console filled up with:

    Uncaught InvalidStateError: Failed to execute 'decode' on 'VideoDecoder':
    Cannot call 'decode' on a closed codec.

Happens whenever the timeline has more than one segment (or a segment repeated). Each clip's
chunks carry timestamps starting from 0, so once we stitch them together the
timestamps reset backwards at every boundary. The decoder rejects the
backwards jump, closes itself, and the setInterval keeps hammering decode()
on the dead codec, leading to the "pausing" and the error spam.

Fix is to renumber the timestamps into a single monotonic sequence before
feeding them to the decoder. Types (key/delta) are left untouched so the
mosh effect still works.